### PR TITLE
Show Timezone on Event Card and updated to support all major timezones

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -66,6 +66,7 @@ export default function Index() {
                       title={event.title}
                       starttime={event.starttime}
                       endtime={event.endtime}
+                      timezone={event.timezone}
                       location={event.location}
                       key={event.id}
                     />
@@ -91,6 +92,7 @@ export default function Index() {
                     starttime={event.starttime}
                     endtime={event.endtime}
                     location={event.location}
+                    timezone={event.timezone}
                     key={event.id}
                   />
                   <div className="mb-4"></div>

--- a/src/app/view-event/page.tsx
+++ b/src/app/view-event/page.tsx
@@ -89,6 +89,7 @@ const ViewEvent = () => {
           title: data[0].title,
           starttime: data[0].starttime,
           endtime: data[0].endtime,
+          timezone: data[0].timezone,
           location: data[0].location,
           config: data[0].config || {},
           mode: data[0].mode || 'weekly', // TODO: need to modify to include both weekly & specific dates
@@ -206,6 +207,7 @@ const ViewEvent = () => {
               starttime={event.starttime}
               endtime={event.endtime}
               location={event.location}
+              timezone={event.timezone}
               key={event.id}
             />
           )}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -7,6 +7,7 @@ interface EventCardProps {
   starttime: string
   endtime: string
   location: string
+  timezone: string
 }
 
 export default function EventCard({
@@ -15,14 +16,19 @@ export default function EventCard({
   starttime,
   endtime,
   location,
+  timezone,
 }: EventCardProps) {
   return (
     <Link href={`/view-event?eventId=${eventId}`}>
       <div className="flex h-48 flex-col justify-between rounded-md bg-white p-4 shadow-lg">
         <div>
           <h2 className="text-lg font-bold">{title}</h2>
-          <p>Start Time: {starttime}</p>
-          <p>End Time: {endtime}</p>
+          <p>
+            Start Time: {starttime} {timezone}
+          </p>
+          <p>
+            End Time: {endtime} {timezone}
+          </p>
           <p>Location: {location}</p>
         </div>
       </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -23,12 +23,6 @@ export default function EventCard({
       <div className="flex h-48 flex-col justify-between rounded-md bg-white p-4 shadow-lg">
         <div>
           <h2 className="text-lg font-bold">{title}</h2>
-          <p>
-            Start Time: {starttime} {timezone}
-          </p>
-          <p>
-            End Time: {endtime} {timezone}
-          </p>
           <p>Location: {location}</p>
         </div>
       </div>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -239,12 +239,20 @@ const EventForm = ({
           <option disabled value="">
             Timezone
           </option>
-          <option>PST (Pacific Standard Time)</option>
-          <option>EST (Eastern Standard Time)</option>
-          <option>GMT (Greenwich Mean Time)</option>
-          <option>CET (Central European Time)</option>
-          <option>IST (Indian Standard Time)</option>
-          <option>JST (Japan Standard Time)</option>
+          <option value="PST">PST (Pacific Standard Time)</option>
+          <option value="MST">MST (Mountain Standard Time)</option>
+          <option value="CST">CST (Central Standard Time)</option>
+          <option value="EST">EST (Eastern Standard Time)</option>
+          <option value="AKST">AKST (Alaska Standard Time)</option>
+          <option value="HST">HST (Hawaii-Aleutian Standard Time)</option>
+          <option value="GMT">GMT (Greenwich Mean Time)</option>
+          <option value="CET">CET (Central European Time)</option>
+          <option value="EET">EET (Eastern European Time)</option>
+          <option value="CST">CST (China Standard Time)</option>
+          <option value="AST">AST (Atlantic Standard Time)</option>
+          <option value="IST">IST (Indian Standard Time)</option>
+          <option value="JST">JST (Japan Standard Time)</option>
+          <option value="AEST">AEST (Australian Eastern Standard Time)</option>
         </select>
       </form>
     </>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -4,7 +4,7 @@ import { days, modeOptions } from '@/utils/dateUtils'
 import { useState } from 'react'
 import Calendar from 'react-calendar'
 // import 'react-calendar/dist/Calendar.css'
-import { times } from '@/utils/timeUtils'
+import { times, sortedTimeZones } from '@/utils/timeUtils'
 // import calendarstyles
 import '@/app/calendarStyles.css'
 
@@ -239,20 +239,11 @@ const EventForm = ({
           <option disabled value="">
             Timezone
           </option>
-          <option value="PST">PST (Pacific Standard Time)</option>
-          <option value="MST">MST (Mountain Standard Time)</option>
-          <option value="CST">CST (Central Standard Time)</option>
-          <option value="EST">EST (Eastern Standard Time)</option>
-          <option value="AKST">AKST (Alaska Standard Time)</option>
-          <option value="HST">HST (Hawaii-Aleutian Standard Time)</option>
-          <option value="GMT">GMT (Greenwich Mean Time)</option>
-          <option value="CET">CET (Central European Time)</option>
-          <option value="EET">EET (Eastern European Time)</option>
-          <option value="CST">CST (China Standard Time)</option>
-          <option value="AST">AST (Atlantic Standard Time)</option>
-          <option value="IST">IST (Indian Standard Time)</option>
-          <option value="JST">JST (Japan Standard Time)</option>
-          <option value="AEST">AEST (Australian Eastern Standard Time)</option>
+          {sortedTimeZones.map(({ value, label }, key) => (
+            <option key={key} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
       </form>
     </>

--- a/src/utils/eventsUtils.ts
+++ b/src/utils/eventsUtils.ts
@@ -6,6 +6,7 @@ export interface Event {
   title: string
   starttime: string
   endtime: string
+  timezone: string
   location: string
   config: { [key: string]: boolean }
   mode: string

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -31,3 +31,36 @@ export const generateTimeRange = (
 
   return generateTimeRange
 }
+
+const timeZones = [
+  { value: 'PST', label: 'UTC−08:00 PST (Pacific Standard Time)' },
+  { value: 'MST', label: 'UTC−07:00 MST (Mountain Standard Time)' },
+  { value: 'CST', label: 'UTC−06:00 CST (Central Standard Time)' },
+  { value: 'EST', label: 'UTC−05:00 Eastern Standard Time' },
+  { value: 'AKST', label: 'UTC−09:00 AKST (Alaska Standard Time)' },
+  { value: 'HST', label: 'UTC−10:00 HST (Hawaii-Aleutian Standard Time)' },
+  { value: 'GMT', label: 'UTC−00:00 GMT (Greenwich Mean Time)' },
+  { value: 'CET', label: 'UTC+01:00 CET (Central European Time)' },
+  { value: 'EET', label: 'UTC+02:00 EET (Eastern European Time)' },
+  { value: 'CST', label: 'UTC+08:00 CST (China Standard Time)' },
+  { value: 'AST', label: 'UTC−04:00 AST (Atlantic Standard Time)' },
+  { value: 'IST', label: 'UTC+05:30 IST (Indian Standard Time)' },
+  { value: 'JST', label: 'UTC+09:00 JST (Japan Standard Time)' },
+  { value: 'AEST', label: 'UTC+10:00 AEST (Australian Eastern Standard Time)' },
+]
+
+// Sorts time zones by UTC time, from negative to positive
+export const sortedTimeZones = timeZones.sort((a, b) => {
+  const getUTCOffset = (label: any) => {
+    const match = label.match(/UTC([−+])(\d{2}):(\d{2})/)
+    if (!match) return 0
+
+    const sign = match[1] === '−' ? -1 : 1
+    const hours = parseInt(match[2], 10)
+    const minutes = parseInt(match[3], 10)
+
+    return sign * (hours + minutes / 60)
+  }
+
+  return getUTCOffset(a.label) - getUTCOffset(b.label)
+})


### PR DESCRIPTION
Features added:
1. More time zones added.
2. The DB now stores the time zone's abbreviation only (Pacific Standard Time becomes PST)
3. Time zone abbreviation is now on the event card next to the start and end times. (Ex. Start time: 9:00 AM PST)