### PR TITLE
Bug fix for last row of availability grid not working if start and end times were the same

### DIFF
--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -119,13 +119,9 @@ const Grid = ({
               endIndex = timeArray.length // Set to the end of the timeArray
             }
 
-            // Check if the start and end index are valid
-            if (startIndex !== -1 && endIndex !== -1 && startIndex < endIndex) {
-              for (let i = startIndex; i < endIndex; i++) {
-                // Instead of just setting to true, increment a counter to keep track of how many people are available at that time
-                newGrid[i][colIndex] = (newGrid[i][colIndex] || 0) + 1
-              }
-            }
+            // Instead of just setting to true, increment a counter to keep track of how many people are available at that time
+            newGrid[startIndex][colIndex] =
+              (newGrid[startIndex][colIndex] || 0) + 1
           })
         })
       })

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -119,9 +119,20 @@ const Grid = ({
               endIndex = timeArray.length // Set to the end of the timeArray
             }
 
+            console.log('timeslot', timeSlot)
+            console.log('startIndex', startIndex)
+            console.log('endIndex', endIndex)
+
             // Instead of just setting to true, increment a counter to keep track of how many people are available at that time
-            newGrid[startIndex][colIndex] =
-              (newGrid[startIndex][colIndex] || 0) + 1
+            for (let i = startIndex; i < endIndex; i++) {
+              newGrid[i][colIndex] = (newGrid[i][colIndex] || 0) + 1
+            }
+
+            // edge case where start and end times are the same so endIndex is 0 and startIndex is timeArray.length - 2
+            if (endIndex === 0) {
+              newGrid[startIndex][colIndex] =
+                (newGrid[startIndex][colIndex] || 0) + 1
+            }
           })
         })
       })

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -114,11 +114,6 @@ const Grid = ({
             const startIndex = timeArray.indexOf(timeSlot.beginning)
             let endIndex = timeArray.indexOf(timeSlot.end)
 
-            // Handle case where end time is not found in the timeArray (endIndex being -1)
-            if (endIndex === -1) {
-              endIndex = timeArray.length // Set to the end of the timeArray
-            }
-
             console.log('timeslot', timeSlot)
             console.log('startIndex', startIndex)
             console.log('endIndex', endIndex)

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -114,10 +114,6 @@ const Grid = ({
             const startIndex = timeArray.indexOf(timeSlot.beginning)
             let endIndex = timeArray.indexOf(timeSlot.end)
 
-            console.log('timeslot', timeSlot)
-            console.log('startIndex', startIndex)
-            console.log('endIndex', endIndex)
-
             // Instead of just setting to true, increment a counter to keep track of how many people are available at that time
             for (let i = startIndex; i < endIndex; i++) {
               newGrid[i][colIndex] = (newGrid[i][colIndex] || 0) + 1

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -29,8 +29,6 @@ export const generateTimeRange = (
     generateTimeRange.push(times[i % times.length])
   }
 
-  console.log(generateTimeRange)
-
   return generateTimeRange
 }
 


### PR DESCRIPTION
Bug Fixes:
1. If the start and end time of an event was the same (Ex. both are 9:00AM), then the last row's time slots (8:30AM-9:00AM) would not be properly filled in green if the user has it selected as their available time slot.