### PR TITLE
Username display in home, create-event, view-event pages

### DIFF
--- a/src/app/api/users/edit/route.ts
+++ b/src/app/api/users/edit/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createServerClient } from '@/utils/supabase'
+import { UUID } from 'crypto'
+
+export const runtime = 'edge'
+
+export async function PUT(request: Request) {
+  const cookieStore = cookies()
+  const supabase = createServerClient(cookieStore)
+  const body = await request.json()
+
+  const { data, error } = await supabase
+    .from('users')
+    .update({ username: body.username })
+    .eq('id', body.id)
+
+  if (error) {
+    return NextResponse.json({
+      status: 400,
+      message: 'Error editing user: ' + error,
+    })
+  }
+  return NextResponse.json(data)
+}

--- a/src/app/api/users/edit/route.ts
+++ b/src/app/api/users/edit/route.ts
@@ -10,6 +10,25 @@ export async function PUT(request: Request) {
   const supabase = createServerClient(cookieStore)
   const body = await request.json()
 
+  if (!body.name) {
+    return NextResponse.json({ message: 'Name is required' }, { status: 400 })
+  } else if (body.name.length == 0) {
+    return NextResponse.json(
+      { message: 'Name must not be empty' },
+      { status: 400 },
+    )
+  } else if (body.name.length > 40) {
+    return NextResponse.json(
+      { message: 'Name must be less than or equal to 40 characters' },
+      { status: 400 },
+    )
+  } else if (typeof body.name != 'string') {
+    return NextResponse.json(
+      { message: 'Name must be a string' },
+      { status: 400 },
+    )
+  }
+
   const { data, error } = await supabase
     .from('users')
     .update({ name: body.name })

--- a/src/app/api/users/edit/route.ts
+++ b/src/app/api/users/edit/route.ts
@@ -12,8 +12,9 @@ export async function PUT(request: Request) {
 
   const { data, error } = await supabase
     .from('users')
-    .update({ username: body.username })
+    .update({ name: body.name })
     .eq('id', body.id)
+    .select()
 
   if (error) {
     return NextResponse.json({

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -163,9 +163,11 @@ export default function CreateEvent() {
         <section //Left side container (Event form)
           className="h-full w-full rounded-lg px-6 pb-16 shadow-lg md:w-[30%]"
         >
-          {userName && isAvailable && (
-            <Username username={userName} setUsername={setUserName} />
-          )}
+          <div className="mb-6">
+            {userName != null && isAvailable && (
+              <Username username={userName} setUsername={setUserName} />
+            )}
+          </div>
           <EventForm
             title={title}
             setTitle={setTitle}

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -28,12 +28,14 @@ export default function CreateEvent() {
   const dialogRef = useRef<HTMLDialogElement>(null) // modal
 
   const [isButtonsVisible, setIsButtonsVisible] = useState(false) // New state to control visibility of buttons
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     // Check if user is signed in
+    const promises = []
     if (localStorage.getItem('username')) {
       setUserName(localStorage.getItem('username') as string)
-      getUser(localStorage.getItem('username') as UUID)
+      const promise = getUser(localStorage.getItem('username') as UUID)
         .then((data) => {
           if (data) {
             setUserName(data[0].name)
@@ -42,7 +44,11 @@ export default function CreateEvent() {
         .catch((error) => {
           console.error('Error:', error.message)
         })
+      promises.push(promise)
     }
+    Promise.all(promises).then(() => {
+      setLoading(false)
+    })
   }, [])
 
   //added router to redirect to view-event page after creating event
@@ -140,7 +146,7 @@ export default function CreateEvent() {
 
   // Function to open modal for after clicking "Sign In"
   const openModal = () => {
-    if (dialogRef.current && userName === '') {
+    if (dialogRef.current && !userName) {
       dialogRef.current.showModal()
     } else {
       setIsAvailable(true)

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -10,6 +10,7 @@ import EventForm from '@/components/EventForm'
 import Grid from '@/components/AvailabilityGrid'
 import Responses from '@/components/Responses'
 import Header from '@/components/Header'
+import Username from '@/components/Username'
 
 export default function CreateEvent() {
   const [title, setTitle] = useState<string | null>('')
@@ -23,7 +24,7 @@ export default function CreateEvent() {
   const [schedule, setSchedule] = useState<Schedule>({})
 
   const [isAvailable, setIsAvailable] = useState(false) // set to true when name is entered at sign in, Determines if the grid is selectable (selection mode)
-  const [userName, setUserName] = useState('') // set to name entered at sign in
+  const [userName, setUserName] = useState<string | null>(null) // set to name entered at sign in
   const dialogRef = useRef<HTMLDialogElement>(null) // modal
 
   const [isButtonsVisible, setIsButtonsVisible] = useState(false) // New state to control visibility of buttons
@@ -104,7 +105,7 @@ export default function CreateEvent() {
 
     try {
       await addUserCreateEvent(
-        userName,
+        userName ? userName : 'Guest',
         title as string,
         description,
         earliestTime,
@@ -154,8 +155,11 @@ export default function CreateEvent() {
         className="flex min-h-screen w-full flex-col gap-8 p-8 md:flex-row"
       >
         <section //Left side container (Event form)
-          className="h-full w-full rounded-lg px-6 py-16 shadow-lg md:w-[30%]"
+          className="h-full w-full rounded-lg px-6 pb-16 shadow-lg md:w-[30%]"
         >
+          {userName && isAvailable && (
+            <Username username={userName} setUsername={setUserName} />
+          )}
           <EventForm
             title={title}
             setTitle={setTitle}
@@ -195,7 +199,7 @@ export default function CreateEvent() {
                   type="text"
                   placeholder="Enter Your Name"
                   className="input input-bordered w-full max-w-xs py-4"
-                  value={userName}
+                  value={userName ? userName : ''}
                   onChange={(e) => {
                     setUserName(e.target.value)
                   }}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -109,7 +109,7 @@ export default function Index() {
       <div className="container mx-auto p-4">
         <div className="flex">
           <div className="w-3/4 p-4">
-            <div className="mb-4 flex items-center justify-start">
+            <div className="mb-10 flex items-center justify-start">
               <h1 className="mr-6 text-2xl font-black font-extrabold">
                 My Events
               </h1>
@@ -117,7 +117,7 @@ export default function Index() {
                 <button className="btn btn-primary">Create Event</button>
               </Link>
               <div className="ml-4"></div> {/* spacing */}
-              {username && !isLoading && (
+              {username != null && !isLoading && (
                 <Username username={username} setUsername={setUsername} />
               )}
             </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -25,7 +25,7 @@ export default function Index() {
   }>({})
   const [isLoading, setIsLoading] = useState(true)
   const [eventIds, setEventIds] = useState<Set<UUID>>(new Set())
-  const [username, setUsername] = useState('')
+  const [username, setUsername] = useState<string | null>(null)
   const [isEditingUsername, setIsEditingUsername] = useState(false)
   const [usernameTooLongError, setUsernameTooLongError] = useState(false)
 
@@ -109,7 +109,7 @@ export default function Index() {
       <div className="container mx-auto p-4">
         <div className="flex">
           <div className="w-3/4 p-4">
-            <Username />
+            <Username username={username} setUsername={setUsername} />
             <div className="mb-4 flex items-center justify-start">
               <h1 className="mr-6 text-2xl font-black font-extrabold">
                 My Events

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -6,6 +6,7 @@ import SignUpUserSteps from '@/components/SignUpUserSteps'
 import Header from '@/components/Header'
 import { createServerClient, createBrowserClient } from '@/utils/supabase'
 import EventCard from '@/components/EventCard'
+import Username from '@/components/Username'
 import ThemeToggle from '@/components/ThemeToggle'
 import { Suspense, useEffect, useState } from 'react'
 import { UUID } from 'crypto'
@@ -26,6 +27,7 @@ export default function Index() {
   const [eventIds, setEventIds] = useState<Set<UUID>>(new Set())
   const [username, setUsername] = useState('')
   const [isEditingUsername, setIsEditingUsername] = useState(false)
+  const [usernameTooLongError, setUsernameTooLongError] = useState(false)
 
   useEffect(() => {
     const eventIdSet = new Set<UUID>()
@@ -107,61 +109,7 @@ export default function Index() {
       <div className="container mx-auto p-4">
         <div className="flex">
           <div className="w-3/4 p-4">
-            <div className="mb-8 flex items-center">
-              <h1 className="pb-4 pt-4 text-xl">Username: </h1>
-              {isEditingUsername ? (
-                <div className="ml-4 flex items-center">
-                  <input
-                    className="text-l input input-sm mr-4 border-gray-300 font-normal focus-visible:ring-0"
-                    type="text"
-                    value={username}
-                    size={60}
-                    onChange={(e) => setUsername(e.target.value)}
-                  />
-                  <button
-                    className="btn btn-primary btn-sm"
-                    onClick={() => {
-                      setIsEditingUsername(false)
-                      editUser(
-                        localStorage.getItem('username') as UUID,
-                        username,
-                      )
-                    }}
-                  >
-                    Save
-                  </button>
-                </div>
-              ) : (
-                <div className="flex">
-                  <h1 className="ml-4 mr-2 text-xl">{username}</h1>
-                  <button>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-6 w-6"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      onClick={() => {
-                        setIsEditingUsername(true)
-                      }}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 20h9"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M16.5 3.5a2.121 2.121 0 113 3L7 19.5 3 21l1.5-4L16.5 3.5z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              )}
-            </div>
+            <Username />
             <div className="mb-4 flex items-center justify-start">
               <h1 className="mr-6 text-2xl font-black font-extrabold">
                 My Events

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -41,6 +41,7 @@ export default function Index() {
           data.forEach((event: Event) => {
             eventIdSet.add(event.id)
           })
+          promises.push(getEventPromise)
         })
         .catch((error) => {
           console.error('Error:', error.message)
@@ -49,9 +50,8 @@ export default function Index() {
         localStorage.getItem('username') as UUID,
       ).then((data) => {
         setUsername(data[0].name)
+        promises.push(getUserPromise)
       })
-      promises.push(getEventPromise)
-      promises.push(getUserPromise)
     } else {
       setIsLoading(false)
     }
@@ -109,7 +109,6 @@ export default function Index() {
       <div className="container mx-auto p-4">
         <div className="flex">
           <div className="w-3/4 p-4">
-            <Username username={username} setUsername={setUsername} />
             <div className="mb-4 flex items-center justify-start">
               <h1 className="mr-6 text-2xl font-black font-extrabold">
                 My Events
@@ -117,6 +116,10 @@ export default function Index() {
               <Link href="/create-event">
                 <button className="btn btn-primary">Create Event</button>
               </Link>
+              <div className="ml-4"></div> {/* spacing */}
+              {username && !isLoading && (
+                <Username username={username} setUsername={setUsername} />
+              )}
             </div>
             {!isLoading &&
               (myEvents.length === 0 ? (

--- a/src/app/view-event/page.tsx
+++ b/src/app/view-event/page.tsx
@@ -19,7 +19,7 @@ import EventView from '@/components/EventView'
 import EventCard from '@/components/EventCard'
 import Grid from '@/components/AvailabilityGrid'
 import Responses from '@/components/Responses'
-import { create } from 'domain'
+import Username from '@/components/Username'
 
 const ViewEvent = () => {
   const searchParams = useSearchParams()
@@ -28,7 +28,7 @@ const ViewEvent = () => {
   const [error, setError] = useState<string | null>(null)
   const [recentlyViewedEvents, setRecentlyViewedEvents] = useState<Event[]>([])
   const [schedule, setSchedule] = useState<Schedule>({})
-  const [userName, setUserName] = useState<string>('') // set to name entered when adding availability
+  const [userName, setUserName] = useState<string | null>(null) // set to name entered when adding availability
   const [userAvailability, setUserAvailability] = useState<Schedule>({})
 
   const [isAvailable, setIsAvailable] = useState(false)
@@ -184,8 +184,11 @@ const ViewEvent = () => {
         className="flex min-h-screen w-full flex-col gap-8 p-8 md:flex-row"
       >
         <section //Left side container (Event form)
-          className="h-full w-full rounded-lg px-6 py-16 shadow-lg md:w-[30%]"
+          className="h-full w-full rounded-lg px-6 pb-16 shadow-lg md:w-[30%]"
         >
+          {userName && isSignedIn && (
+            <Username username={userName} setUsername={setUserName} />
+          )}
           {event && (
             <EventCard // Event Card to display Event Details
               eventId={event.id}
@@ -267,7 +270,7 @@ const ViewEvent = () => {
                   type="text"
                   placeholder="Enter Your Name"
                   className="input input-bordered w-full max-w-xs bg-white py-4"
-                  value={userName}
+                  value={userName ? userName : ''}
                   onChange={(e) => {
                     setUserName(e.target.value)
                   }}
@@ -310,7 +313,7 @@ const ViewEvent = () => {
                 <button
                   className="btn btn-primary rounded-full px-4 py-2 text-white"
                   onClick={() => {
-                    if (isNewUser) {
+                    if (isNewUser && userName) {
                       createUser(userName).then((data) => {
                         addAttendee(
                           eventId as UUID,

--- a/src/components/Username.tsx
+++ b/src/components/Username.tsx
@@ -21,11 +21,11 @@ export default function Username({ username, setUsername }: UsernameProps) {
   return (
     <>
       <div className="flex items-center">
-        <h1 className="text-l pb-4 pt-4">Username: </h1>
+        <h1 className="text-l pb-2 pt-2">Username: </h1>
         {isEditingUsername ? (
           <div className="flex items-center">
             <input
-              className="text-l input input-sm mr-2 border-gray-300 font-normal focus-visible:ring-0"
+              className="text-l input input-sm mx-2 border-gray-300 font-normal focus-visible:ring-0"
               type="text"
               value={username ? username : ''}
               size={20}
@@ -54,7 +54,7 @@ export default function Username({ username, setUsername }: UsernameProps) {
           </div>
         ) : (
           <div className="flex">
-            <h1 className="text-l ml-4 mr-2">{username}</h1>
+            <h1 className="text-l mx-2">{username}</h1>
             <button>
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Username.tsx
+++ b/src/components/Username.tsx
@@ -1,44 +1,48 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { use, useEffect, useState } from 'react'
 import { getUser, editUser } from '@/utils/userUtils'
 import { UUID } from 'crypto'
 
-export default function Username() {
-  const [username, setUsername] = useState('')
+interface UsernameProps {
+  username: string | null
+  setUsername: React.Dispatch<React.SetStateAction<string | null>>
+}
+
+export default function Username({ username, setUsername }: UsernameProps) {
   const [isEditingUsername, setIsEditingUsername] = useState(false)
-  const [usernameTooLongError, setUsernameTooLongError] = useState(false)
+  const [usernameLengthError, setUsernameLengthError] = useState(false)
 
   useEffect(() => {
-    getUser(localStorage.getItem('username') as UUID).then((data) => {
-      setUsername(data[0].name)
-    })
+    if (!username) {
+      setUsername('Guest')
+    }
   }, [])
 
   return (
     <>
       <div className="flex items-center">
-        <h1 className="pb-4 pt-4 text-xl">Username: </h1>
+        <h1 className="text-l pb-4 pt-4">Username: </h1>
         {isEditingUsername ? (
-          <div className="ml-4 flex items-center">
+          <div className="flex items-center">
             <input
-              className="text-l input input-sm mr-4 border-gray-300 font-normal focus-visible:ring-0"
+              className="text-l input input-sm mr-2 border-gray-300 font-normal focus-visible:ring-0"
               type="text"
-              value={username}
-              size={60}
+              value={username ? username : ''}
+              size={20}
               onChange={(e) => {
                 // must be less than or equal to 40 characters
                 setUsername(e.target.value)
-                if (e.target.value.length <= 40) {
-                  setUsernameTooLongError(false)
+                if (e.target.value.length > 40 || e.target.value.length === 0) {
+                  setUsernameLengthError(true)
                 } else {
-                  setUsernameTooLongError(true)
+                  setUsernameLengthError(false)
                 }
               }}
             />
             <button
               className="btn btn-primary btn-sm"
               onClick={() => {
-                if (username.length <= 40) {
+                if (username && username.length <= 40 && username.length > 0) {
                   // only save if username is less than or equal to 40 characters
                   setIsEditingUsername(false)
                   editUser(localStorage.getItem('username') as UUID, username)
@@ -50,7 +54,7 @@ export default function Username() {
           </div>
         ) : (
           <div className="flex">
-            <h1 className="ml-4 mr-2 text-xl">{username}</h1>
+            <h1 className="text-l ml-4 mr-2">{username}</h1>
             <button>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -79,9 +83,9 @@ export default function Username() {
           </div>
         )}
       </div>
-      {usernameTooLongError ? (
+      {usernameLengthError ? (
         <p className="text-red-500">
-          Username cannot be more than 40 characters!
+          Username must be between 1 and 40 characters long!
         </p>
       ) : (
         <div className="mb-6"></div>

--- a/src/components/Username.tsx
+++ b/src/components/Username.tsx
@@ -20,76 +20,83 @@ export default function Username({ username, setUsername }: UsernameProps) {
 
   return (
     <>
-      <div className="flex items-center">
-        <h1 className="text-l pb-2 pt-2">Username: </h1>
-        {isEditingUsername ? (
-          <div className="flex items-center">
-            <input
-              className="text-l input input-sm mx-2 border-gray-300 font-normal focus-visible:ring-0"
-              type="text"
-              value={username ? username : ''}
-              size={20}
-              onChange={(e) => {
-                // must be less than or equal to 40 characters
-                setUsername(e.target.value)
-                if (e.target.value.length > 40 || e.target.value.length === 0) {
-                  setUsernameLengthError(true)
-                } else {
-                  setUsernameLengthError(false)
-                }
-              }}
-            />
-            <button
-              className="btn btn-primary btn-sm"
-              onClick={() => {
-                if (username && username.length <= 40 && username.length > 0) {
-                  // only save if username is less than or equal to 40 characters
-                  setIsEditingUsername(false)
-                  editUser(localStorage.getItem('username') as UUID, username)
-                }
-              }}
-            >
-              Save
-            </button>
-          </div>
-        ) : (
-          <div className="flex">
-            <h1 className="text-l mx-2">{username}</h1>
-            <button>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-6 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+      <div className="flex flex-col items-center">
+        <div className="flex items-center">
+          <h1 className="text-l pb-2 pt-2">Username: </h1>
+          {isEditingUsername ? (
+            <div className="flex items-center">
+              <input
+                className="text-l input input-sm mx-2 border-gray-300 font-normal focus-visible:ring-0"
+                type="text"
+                value={username ? username : ''}
+                size={20}
+                onChange={(e) => {
+                  // must be less than or equal to 40 characters
+                  setUsername(e.target.value)
+                  if (
+                    e.target.value.length > 40 ||
+                    e.target.value.length === 0
+                  ) {
+                    setUsernameLengthError(true)
+                  } else {
+                    setUsernameLengthError(false)
+                  }
+                }}
+              />
+              <button
+                className="btn btn-primary btn-sm"
                 onClick={() => {
-                  setIsEditingUsername(true)
+                  if (
+                    username &&
+                    username.length <= 40 &&
+                    username.length > 0
+                  ) {
+                    // only save if username is less than or equal to 40 characters
+                    setIsEditingUsername(false)
+                    editUser(localStorage.getItem('username') as UUID, username)
+                  }
                 }}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 20h9"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16.5 3.5a2.121 2.121 0 113 3L7 19.5 3 21l1.5-4L16.5 3.5z"
-                />
-              </svg>
-            </button>
-          </div>
+                Save
+              </button>
+            </div>
+          ) : (
+            <div className="flex">
+              <h1 className="text-l mx-2">{username}</h1>
+              <button>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  onClick={() => {
+                    setIsEditingUsername(true)
+                  }}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 20h9"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16.5 3.5a2.121 2.121 0 113 3L7 19.5 3 21l1.5-4L16.5 3.5z"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+        {usernameLengthError && (
+          <p className="absolute mt-10 text-sm text-red-500">
+            Username must be between 1 and 40 characters long!
+          </p>
         )}
       </div>
-      {usernameLengthError ? (
-        <p className="text-red-500">
-          Username must be between 1 and 40 characters long!
-        </p>
-      ) : (
-        <div className="mb-6"></div>
-      )}
     </>
   )
 }

--- a/src/components/Username.tsx
+++ b/src/components/Username.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { getUser, editUser } from '@/utils/userUtils'
+import { UUID } from 'crypto'
+
+export default function Username() {
+  const [username, setUsername] = useState('')
+  const [isEditingUsername, setIsEditingUsername] = useState(false)
+  const [usernameTooLongError, setUsernameTooLongError] = useState(false)
+
+  useEffect(() => {
+    getUser(localStorage.getItem('username') as UUID).then((data) => {
+      setUsername(data[0].name)
+    })
+  }, [])
+
+  return (
+    <>
+      <div className="flex items-center">
+        <h1 className="pb-4 pt-4 text-xl">Username: </h1>
+        {isEditingUsername ? (
+          <div className="ml-4 flex items-center">
+            <input
+              className="text-l input input-sm mr-4 border-gray-300 font-normal focus-visible:ring-0"
+              type="text"
+              value={username}
+              size={60}
+              onChange={(e) => {
+                // must be less than or equal to 40 characters
+                setUsername(e.target.value)
+                if (e.target.value.length <= 40) {
+                  setUsernameTooLongError(false)
+                } else {
+                  setUsernameTooLongError(true)
+                }
+              }}
+            />
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => {
+                if (username.length <= 40) {
+                  // only save if username is less than or equal to 40 characters
+                  setIsEditingUsername(false)
+                  editUser(localStorage.getItem('username') as UUID, username)
+                }
+              }}
+            >
+              Save
+            </button>
+          </div>
+        ) : (
+          <div className="flex">
+            <h1 className="ml-4 mr-2 text-xl">{username}</h1>
+            <button>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                onClick={() => {
+                  setIsEditingUsername(true)
+                }}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 20h9"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16.5 3.5a2.121 2.121 0 113 3L7 19.5 3 21l1.5-4L16.5 3.5z"
+                />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+      {usernameTooLongError ? (
+        <p className="text-red-500">
+          Username cannot be more than 40 characters!
+        </p>
+      ) : (
+        <div className="mb-6"></div>
+      )}
+    </>
+  )
+}

--- a/src/utils/userUtils.ts
+++ b/src/utils/userUtils.ts
@@ -74,7 +74,6 @@ export async function editUser(userId: UUID, name: string) {
       return response.json()
     })
     .then((data) => {
-      console.log('data', data)
       return data
     })
     .catch((error) => {

--- a/src/utils/userUtils.ts
+++ b/src/utils/userUtils.ts
@@ -54,6 +54,34 @@ export async function getUser(userId: UUID) {
     })
 }
 
+export async function editUser(userId: UUID, name: string) {
+  return fetch(`/api/users/edit?userId=${userId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      id: userId,
+      name: name,
+    }),
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.json().then((err) => {
+          throw new Error(err.message)
+        })
+      }
+      return response.json()
+    })
+    .then((data) => {
+      console.log('data', data)
+      return data
+    })
+    .catch((error) => {
+      console.error('Error:', error.message)
+    })
+}
+
 export async function addUserCreateEvent(
   username: string,
   title: string,


### PR DESCRIPTION
New Features:
1. Username is now displayed in the home, create-event, and view-event pages, with "Guest" being the default for new users.
2. Users can edit their username across all events by pressing the pencil icon next to their username. (Username must be 1-40 characters long, otherwise error message is displayed)

Create-event page:
<img width="394" alt="create-event page" src="https://github.com/user-attachments/assets/61ec1190-21e7-4782-8cd0-bb215aa7eefa">

View-event page:
<img width="1320" alt="view-event page" src="https://github.com/user-attachments/assets/0dd43569-47fd-4c81-a096-33d67445465f">

Home page:
<img width="998" alt="home page" src="https://github.com/user-attachments/assets/6f8ff804-2ec6-4bfe-9051-da10a5353f02">

Editing and error message on home (other pages are similar):
<img width="985" alt="Screenshot 2024-09-08 at 6 56 04 PM" src="https://github.com/user-attachments/assets/cfe87921-7290-4d5b-8c89-eff3c92fc66a">
