### PR TITLE
Calendar bug fix for date selection

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -188,7 +188,7 @@ const EventForm = ({
                   let newSpecificDays: string[] = config ? config : []
                   if (
                     !newSpecificDays?.some((day) => {
-                      isSameDate(day, monthDateYear)
+                      return isSameDate(day, monthDateYear)
                     }) &&
                     (newSpecificDays?.length as number) < maxDaysSelectable
                   ) {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -42,7 +42,7 @@ export const isSameDate = (date1: string, date2: string) => {
   const month = months[new Date(date1).getUTCMonth()]
   const dateDay = new Date(date1).getUTCDate()
   const year = new Date(date1).getUTCFullYear()
-  return month + ' ' + dateDay + ' ' + year !== date2
+  return month + ' ' + dateDay + ' ' + year === date2
 }
 
 // if date is in the format 'Month Day Year', return the date in the format of the toString of a date object


### PR DESCRIPTION
Bug Fixes:
1. Fixed bug with calendar date selection not working properly. (Dates were not being selected and deselected properly, leading to duplicate dates being selected)