### PR TITLE
Respondent list moves as user scrolls in view-event and removed respondent list from create-event

### DIFF
--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -257,12 +257,6 @@ export default function CreateEvent() {
             </div>
           )}
         </section>
-
-        <section //Right side container (Responses)
-          className="w-full py-8 md:w-[13%]"
-        >
-          <Responses responders={[]} />
-        </section>
       </div>
     </div>
   )

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -389,7 +389,7 @@ const ViewEvent = () => {
           </section>
 
           <section //Right side container (Responses)
-            className="w-full py-8 md:w-[13%]"
+            className="sticky top-0 h-1 w-full py-8 md:w-[13%]"
           >
             <Responses responders={responders} hoveredCell={hoveredCell} />
           </section>


### PR DESCRIPTION
New Features:
1. The respondents list in view-event page moves as the user scrolls if the grid is too long.
2. Respondents list removed from create-event page.

Example of view-event:
<img width="1354" alt="Screenshot 2024-09-14 at 6 29 21 PM" src="https://github.com/user-attachments/assets/06acbc38-cc47-4272-89ce-02893b277e48">

Create-event:
<img width="1350" alt="Screenshot 2024-09-14 at 6 31 04 PM" src="https://github.com/user-attachments/assets/ad3d331c-c7b8-4a48-955d-47170980b63a">
