### PR TITLE
Preferred and regular times availability feature for both weekly and specific events

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/utils/dateUtils'
 import { addAttendee, TimeSegment, Schedule } from '@/utils/attendeesUtils'
 import { UUID } from 'crypto'
+import ToggleButton from '@/components/ToggleButton'
+import { time } from 'console'
 
 interface GridProps {
   earliestTime: string
@@ -63,6 +65,7 @@ const Grid = ({
     rowIndex: number
     colIndex: number
   } | null>(null)
+  const [timeSegmentType, setTimeSegmentType] = useState('Regular')
 
   const addDateToSchedule = (date: string, timeSegments: TimeSegment[]) => {
     const newSchedule = { ...schedule }
@@ -237,7 +240,7 @@ const Grid = ({
     const selectedTimeSegment = {
       beginning: timeArray[rowIndex],
       end: timeArray[rowIndex + 1],
-      type: 'Regular',
+      type: timeSegmentType,
     }
 
     if (
@@ -291,146 +294,158 @@ const Grid = ({
   }
 
   return (
-    <div onMouseUp={handleMouseUp} onMouseLeave={handleMouseLeaveGrid}>
-      {/* Column Header for weekdays corresponding to specific dates */}
-      <div>
-        {mode === 'specific' && (
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: `repeat(${dimensions.width || 1}, 1fr)`,
-              marginLeft: '62px',
-            }}
-          >
-            {config?.map((dateString: string, index: number) => (
-              <div
-                key={index}
-                className="flex flex-col items-center justify-center border-gray-300 text-xs text-gray-400"
-              >
-                <div>
-                  {new Date(dateString).toLocaleDateString('en-US', {
-                    weekday: 'short',
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      <div
-        className="grid-container"
-        style={{ display: 'grid', gridTemplateColumns: 'auto 1fr' }}
-      >
-        {/* Time row headers */}
-        <div
-          className="grid-time-headers"
-          style={{
-            display: 'grid',
-            gridTemplateRows: `repeat(${dimensions.height}, 32px)`,
-            alignItems: 'flex-start',
-          }}
-        >
-          {timeArray.map(
-            (time, index) =>
-              index !== timeArray.length && (
+    <div className="flex flex-col">
+      <div onMouseUp={handleMouseUp} onMouseLeave={handleMouseLeaveGrid}>
+        {/* Column Header for weekdays corresponding to specific dates */}
+        <div>
+          {mode === 'specific' && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${dimensions.width || 1}, 1fr)`,
+                marginLeft: '62px',
+              }}
+            >
+              {config?.map((dateString: string, index: number) => (
                 <div
                   key={index}
-                  className="flex items-start justify-start border-gray-300 pr-2 text-xs text-gray-600"
-                  style={{ height: '64px', lineHeight: '64px' }}
+                  className="flex flex-col items-center justify-center border-gray-300 text-xs text-gray-400"
                 >
-                  {time}
+                  <div>
+                    {new Date(dateString).toLocaleDateString('en-US', {
+                      weekday: 'short',
+                    })}
+                  </div>
                 </div>
-              ),
+              ))}
+            </div>
           )}
         </div>
 
-        <div>
-          {/* Grid Column header displaying days of the week */}
+        <div
+          className="grid-container"
+          style={{ display: 'grid', gridTemplateColumns: 'auto 1fr' }}
+        >
+          {/* Time row headers */}
           <div
-            className="grid-header"
+            className="grid-time-headers"
             style={{
               display: 'grid',
-              gridTemplateColumns: `repeat(${dimensions.width || 1}, 1fr)`, // Ensure at least one column
+              gridTemplateRows: `repeat(${dimensions.height}, 32px)`,
+              alignItems: 'flex-start',
             }}
           >
-            {(dates?.length as number) > 0 ? (
-              dates?.map((day, index) => (
-                <div
-                  key={index}
-                  className="flex items-start justify-center border-gray-300 text-[15px] text-gray-600"
-                  style={{ height: '2rem' }}
-                >
-                  {day}
-                </div>
-              ))
-            ) : (
-              // Placeholder for grid header (fixes alignment of times and grid rows when no dates are present)
-              <div
-                className="flex items-center justify-center border-gray-300 text-sm text-gray-600"
-                style={{ height: '2rem' }}
-              ></div>
+            {timeArray.map(
+              (time, index) =>
+                index !== timeArray.length && (
+                  <div
+                    key={index}
+                    className="flex items-start justify-start border-gray-300 pr-2 text-xs text-gray-600"
+                    style={{ height: '64px', lineHeight: '64px' }}
+                  >
+                    {time}
+                  </div>
+                ),
             )}
           </div>
 
-          {/* Main Grid body cells for selecting and deselecting */}
-          <div
-            className={`grid h-full border border-gray-300`}
-            style={{
-              display: 'grid',
-              gridTemplateColumns: `repeat(${dimensions.width}, 1fr)`,
-              gridTemplateRows: `repeat(${dimensions.height}, 1fr)`,
-              width: '100%',
-              height: `${dimensions.height * 32 + 1}px`, // 32px height per row and add 1px to height to account for border
-            }}
-            onMouseLeave={handleMouseLeaveGrid} // Handle mouse leave for grid body
-          >
-            {grid.map((row, rowIndex) =>
-              row.map((numRespondersAvailable, colIndex) => (
+          <div>
+            {/* Grid Column header displaying days of the week */}
+            <div
+              className="grid-header"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${dimensions.width || 1}, 1fr)`, // Ensure at least one column
+              }}
+            >
+              {(dates?.length as number) > 0 ? (
+                dates?.map((day, index) => (
+                  <div
+                    key={index}
+                    className="flex items-start justify-center border-gray-300 text-[15px] text-gray-600"
+                    style={{ height: '2rem' }}
+                  >
+                    {day}
+                  </div>
+                ))
+              ) : (
+                // Placeholder for grid header (fixes alignment of times and grid rows when no dates are present)
                 <div
-                  key={`${rowIndex}-${colIndex}`}
-                  className={`flex h-8 items-center justify-center border-[0.5px] border-gray-200 
-                    ${
-                      numRespondersAvailable && isAvailable
-                        ? 'bg-emerald-300'
-                        : isAvailable
-                          ? 'bg-red-50'
-                          : '' // Red while editing schedule
-                    }
-                    ${
-                      numRespondersAvailable && responders
-                        ? generateGridGradient(
-                            numRespondersAvailable,
-                            responders?.length || 0,
-                          )
-                        : ''
-                    }
-                    ${
-                      // Change cursor to pointer if grid is selectable
-                      isAvailable ? 'cursor-pointer' : 'cursor-default'
-                    } ${
-                      // Add border-dashed to cell if it is the hovered cell
-                      hoveredCell?.rowIndex === rowIndex &&
-                      hoveredCell?.colIndex === colIndex
-                        ? 'border-1 border-dashed ring-1 ring-gray-900 ring-opacity-10 drop-shadow-md hover:border-black'
-                        : ''
-                    }`}
-                  onMouseDown={
-                    (dates?.length as number) > 0
-                      ? () => handleMouseDown(rowIndex, colIndex)
-                      : undefined
-                  }
-                  onMouseEnter={
-                    (dates?.length as number) > 0
-                      ? () => handleMouseEnter(rowIndex, colIndex)
-                      : undefined
-                  }
+                  className="flex items-center justify-center border-gray-300 text-sm text-gray-600"
+                  style={{ height: '2rem' }}
                 ></div>
-              )),
-            )}
+              )}
+            </div>
+
+            {/* Main Grid body cells for selecting and deselecting */}
+            <div
+              className={`grid h-full border border-gray-300`}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${dimensions.width}, 1fr)`,
+                gridTemplateRows: `repeat(${dimensions.height}, 1fr)`,
+                width: '100%',
+                height: `${dimensions.height * 32 + 1}px`, // 32px height per row and add 1px to height to account for border
+              }}
+              onMouseLeave={handleMouseLeaveGrid} // Handle mouse leave for grid body
+            >
+              {grid.map((row, rowIndex) =>
+                row.map((numRespondersAvailable, colIndex) => (
+                  <div
+                    key={`${rowIndex}-${colIndex}`}
+                    className={`flex h-8 items-center justify-center border-[0.5px] border-gray-200 
+                      ${
+                        numRespondersAvailable && isAvailable
+                          ? timeSegmentType === 'Regular'
+                            ? 'bg-emerald-300'
+                            : 'bg-sky-300'
+                          : isAvailable
+                            ? 'bg-red-50'
+                            : '' // Red while editing schedule
+                      }
+                      ${
+                        numRespondersAvailable && responders
+                          ? generateGridGradient(
+                              numRespondersAvailable,
+                              responders?.length || 0,
+                            )
+                          : ''
+                      }
+                      ${
+                        // Change cursor to pointer if grid is selectable
+                        isAvailable ? 'cursor-pointer' : 'cursor-default'
+                      } ${
+                        // Add border-dashed to cell if it is the hovered cell
+                        hoveredCell?.rowIndex === rowIndex &&
+                        hoveredCell?.colIndex === colIndex
+                          ? 'border-1 border-dashed ring-1 ring-gray-900 ring-opacity-10 drop-shadow-md hover:border-black'
+                          : ''
+                      }`}
+                    onMouseDown={
+                      (dates?.length as number) > 0
+                        ? () => handleMouseDown(rowIndex, colIndex)
+                        : undefined
+                    }
+                    onMouseEnter={
+                      (dates?.length as number) > 0
+                        ? () => handleMouseEnter(rowIndex, colIndex)
+                        : undefined
+                    }
+                  ></div>
+                )),
+              )}
+            </div>
           </div>
         </div>
       </div>
+      {isAvailable && (
+        <div className="flex justify-center">
+          <ToggleButton
+            timeSegmentType={timeSegmentType}
+            setTimeSegmentType={setTimeSegmentType}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -65,7 +65,6 @@ const Grid = ({
     rowIndex: number
     colIndex: number
   } | null>(null)
-  const [timeSegmentType, setTimeSegmentType] = useState('Regular')
   const [displayTimeType, setDisplayTimeType] = useState<
     'Regular' | 'Preferred'
   >('Regular')
@@ -249,7 +248,7 @@ const Grid = ({
     const selectedTimeSegment = {
       beginning: timeArray[rowIndex],
       end: timeArray[rowIndex + 1],
-      type: timeSegmentType,
+      type: displayTimeType,
     }
 
     if (
@@ -305,20 +304,25 @@ const Grid = ({
     const shade = shades[index]
 
     // Check if the time segment is in the schedule
-    const segments = schedule[date] || []
-    for (const segment of segments) {
-      if (time === segment.beginning) {
-        console.log('TRUE')
-      }
-    }
+    // const segments = schedule[date] || []
+    // for (const segment of segments) {
+    //   if (time === segment.beginning) {
+    //     console.log('TRUE')
+    //   }
+    // }
 
-    return displayTimeType === 'Regular'
-      ? `bg-emerald-${shade}`
-      : `bg-sky-${shade}`
+    return `bg-emerald-${shade}`
   }
 
   const getSegmentType = (date: string, time: string, schedule: Schedule) => {
-    const segments = schedule[date] || []
+    const today = new Date()
+    const year = today.getUTCFullYear()
+    const segments =
+      mode === 'specific'
+        ? schedule[
+            convertDateStringToDateObject(date + ' ' + year).toString()
+          ] || []
+        : schedule[date] || []
     for (const segment of segments) {
       if (time === segment.beginning) {
         return segment.type
@@ -426,7 +430,7 @@ const Grid = ({
               {grid.map((row, rowIndex) =>
                 row.map((numRespondersAvailable, colIndex) => {
                   // Convert rowIndex and colIndex to date and time
-                  const date = dates && dates[colIndex]
+                  const date = dates && dates[colIndex] ? dates[colIndex] : ''
                   const time = timeArray[rowIndex]
 
                   const timeSegmentType = getSegmentType(
@@ -448,7 +452,7 @@ const Grid = ({
                               : '' // Red while editing schedule
                         }
                         ${
-                          numRespondersAvailable && responders
+                          numRespondersAvailable && responders && !isAvailable
                             ? generateGridGradient(
                                 numRespondersAvailable,
                                 responders?.length || 0,
@@ -486,14 +490,7 @@ const Grid = ({
           </div>
         </div>
       </div>
-      {isAvailable ? (
-        <div className="flex justify-center">
-          <ToggleButton
-            timeSegmentType={timeSegmentType}
-            setTimeSegmentType={setTimeSegmentType}
-          />
-        </div>
-      ) : (
+      {isAvailable && (
         <div className="mb-2 flex justify-center">
           <button
             onClick={handleToggle}

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -281,7 +281,6 @@ const Grid = ({
       const date = formattedDate(config[colIndex])
       addDateToSchedule(date, [selectedTimeSegment])
     }
-    console.log('schedule', schedule)
     setGrid(newGrid)
   }
 
@@ -302,15 +301,6 @@ const Grid = ({
     const fraction = numRespondersAvailable / totalResponders
     const index = Math.floor(fraction * (shades.length - 1))
     const shade = shades[index]
-
-    // Check if the time segment is in the schedule
-    // const segments = schedule[date] || []
-    // for (const segment of segments) {
-    //   if (time === segment.beginning) {
-    //     console.log('TRUE')
-    //   }
-    // }
-
     return `bg-emerald-${shade}`
   }
 

--- a/src/components/AvailabilityGrid.tsx
+++ b/src/components/AvailabilityGrid.tsx
@@ -66,6 +66,15 @@ const Grid = ({
     colIndex: number
   } | null>(null)
   const [timeSegmentType, setTimeSegmentType] = useState('Regular')
+  const [displayTimeType, setDisplayTimeType] = useState<
+    'Regular' | 'Preferred'
+  >('Regular')
+
+  const handleToggle = () => {
+    setDisplayTimeType((prevType) =>
+      prevType === 'Regular' ? 'Preferred' : 'Regular',
+    )
+  }
 
   const addDateToSchedule = (date: string, timeSegments: TimeSegment[]) => {
     const newSchedule = { ...schedule }
@@ -281,7 +290,9 @@ const Grid = ({
   const generateGridGradient = (
     numRespondersAvailable: number,
     totalResponders: number,
-    segmentType: string | null,
+    date: string,
+    time: string,
+    schedule: Schedule,
   ): string => {
     if (totalResponders === 0) return '' // No responders, no color
 
@@ -292,7 +303,18 @@ const Grid = ({
     const fraction = numRespondersAvailable / totalResponders
     const index = Math.floor(fraction * (shades.length - 1))
     const shade = shades[index]
-    return segmentType === 'Regular' ? `bg-emerald-${shade}` : `bg-sky-${shade}`
+
+    // Check if the time segment is in the schedule
+    const segments = schedule[date] || []
+    for (const segment of segments) {
+      if (time === segment.beginning) {
+        console.log('TRUE')
+      }
+    }
+
+    return displayTimeType === 'Regular'
+      ? `bg-emerald-${shade}`
+      : `bg-sky-${shade}`
   }
 
   const getSegmentType = (date: string, time: string, schedule: Schedule) => {
@@ -430,7 +452,9 @@ const Grid = ({
                             ? generateGridGradient(
                                 numRespondersAvailable,
                                 responders?.length || 0,
-                                timeSegmentType,
+                                date as string,
+                                time,
+                                schedule,
                               )
                             : ''
                         }
@@ -462,12 +486,39 @@ const Grid = ({
           </div>
         </div>
       </div>
-      {isAvailable && (
+      {isAvailable ? (
         <div className="flex justify-center">
           <ToggleButton
             timeSegmentType={timeSegmentType}
             setTimeSegmentType={setTimeSegmentType}
           />
+        </div>
+      ) : (
+        <div className="mb-2 flex justify-center">
+          <button
+            onClick={handleToggle}
+            className={`flex w-40 items-center rounded-full px-4 py-2 transition-colors duration-300
+                ${
+                  displayTimeType === 'Regular'
+                    ? 'bg-emerald-300'
+                    : 'bg-sky-300'
+                }`}
+          >
+            <span
+              className={`mr-3 truncate font-medium text-white`}
+              style={{ maxWidth: 'calc(100% - 2rem)' }} // Ensure text does not overflow the button
+            >
+              {displayTimeType}
+            </span>
+            <div
+              className={`h-6 w-6 transform rounded-full bg-white shadow-md transition-transform duration-300
+                  ${
+                    displayTimeType === 'Regular'
+                      ? 'translate-x-0'
+                      : 'translate-x-6'
+                  }`}
+            ></div>
+          </button>
         </div>
       )}
     </div>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -28,6 +28,16 @@ export default function FAQ() {
       answer:
         'Visit your Event or find and visit the link on the Dashboard.  Look at the availability grid and see when the best time to meet is by hovering over the darkest green cells.  Hovering over a cell identifies which respondents, highlighted in green, are available in the Responders list on the right.',
     },
+    {
+      question: 'What is the difference between Regular and Preferred times?',
+      answer:
+        'Regular times are times you are available to meet, while Preferred times are times you would prefer to meet. Event attendees can see how many attendees are available based on both their regular and preferred times, and use that to determine the best time to meet.',
+    },
+    {
+      question: 'How can I set a preferred time?',
+      answer:
+        'When adding your availability, use the toggle beneath the availability grid to toggle between adding times as "Regular" or "Preferred". "Regular" times are added to the grid in green, while "Preferred" times are added in blue. The grid does not distinguish between the two in view mode, but there will be a list beneath the Responders list of the number of attendees available in times that are marked as "Preferred".',
+    },
   ]
 
   const [openIndex, setOpenIndex] = useState<number | null>(null)

--- a/src/components/PreferredTimes.tsx
+++ b/src/components/PreferredTimes.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react'
+import { Schedule } from '@/utils/attendeesUtils'
+import { convertDateToMonthDayYear } from '@/utils/dateUtils'
+import { times } from '@/utils/timeUtils'
+
+interface PreferredTimesProps {
+  attendeeTimeSegments: Schedule
+  mode: string
+}
+
+export default function PreferredTimes({
+  attendeeTimeSegments,
+  mode,
+}: PreferredTimesProps) {
+  const [timesList, setTimesList] = useState<{ [date: string]: number }>({})
+
+  useEffect(() => {
+    const newTimesList: { [date: string]: number } = {}
+
+    for (const timeSegments of Object.values(attendeeTimeSegments)) {
+      for (const [date, segment] of Object.entries(timeSegments)) {
+        for (const seg of Object.values(segment)) {
+          const timeAndDate =
+            mode === 'specific'
+              ? convertDateToMonthDayYear(new Date(date)) +
+                ' ' +
+                seg.beginning +
+                '-' +
+                seg.end
+              : date + ' ' + seg.beginning + '-' + seg.end // 'Month Day Year Beginning-End'
+          if (seg.type === 'Preferred') {
+            if (newTimesList[timeAndDate]) {
+              newTimesList[timeAndDate] += 1
+            } else {
+              newTimesList[timeAndDate] = 1
+            }
+          }
+        }
+      }
+    }
+
+    setTimesList(newTimesList)
+  }, [attendeeTimeSegments])
+
+  const sortTimesList = Object.entries(timesList).sort((a, b) => {
+    const [dateA, countA] = a
+    const [dateB, countB] = b
+
+    if (countA === countB) {
+      const dateAParsed = new Date(dateA.split(' ')[0])
+      const dateBParsed = new Date(dateB.split(' ')[0])
+      return dateAParsed.getTime() - dateBParsed.getTime()
+    }
+    return countB - countA
+  })
+
+  return (
+    <div className="mt-6">
+      <h3 className="pb-3 text-sm font-medium text-gray-600">
+        Preferred Times
+      </h3>
+      <ul className="text-xs text-gray-500">
+        {sortTimesList.map(([timeAndDate, count], index) => {
+          console.log('timesList in map', timesList)
+          return (
+            <li key={index} className="text-gray-500">
+              {timeAndDate} [{count}]
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/PreferredTimes.tsx
+++ b/src/components/PreferredTimes.tsx
@@ -61,7 +61,6 @@ export default function PreferredTimes({
       </h3>
       <ul className="text-xs text-gray-500">
         {sortTimesList.map(([timeAndDate, count], index) => {
-          console.log('timesList in map', timesList)
           return (
             <li key={index} className="text-gray-500">
               {timeAndDate} [{count}]

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+interface ToggleButtonProps {
+  timeSegmentType: string
+  setTimeSegmentType: React.Dispatch<React.SetStateAction<string>>
+}
+
+export default function ToggleButton({
+  timeSegmentType,
+  setTimeSegmentType,
+}: ToggleButtonProps) {
+  const handleToggle = () => {
+    setTimeSegmentType((prevType) =>
+      prevType === 'Regular' ? 'Preferred' : 'Regular',
+    )
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      className={`flex w-40 items-center rounded-full px-4 py-2 transition-colors duration-300
+        ${timeSegmentType === 'Regular' ? 'bg-emerald-300' : 'bg-sky-300'}`}
+    >
+      <span
+        className={`mr-3 truncate font-medium text-white`}
+        style={{ maxWidth: 'calc(100% - 2rem)' }} // Ensure text does not overflow the button
+      >
+        {timeSegmentType}
+      </span>
+      <div
+        className={`h-6 w-6 transform rounded-full bg-white shadow-md transition-transform duration-300
+          ${timeSegmentType === 'Regular' ? 'translate-x-0' : 'translate-x-6'}`}
+      ></div>
+    </button>
+  )
+}

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -36,6 +36,7 @@ const ViewEvent = () => {
   const [isSignedIn, setIsSignedIn] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [newSchedule, setNewSchedule] = useState<Schedule>({})
+  const [attendeeTimeSegments, setAttendeeTimeSegments] = useState<Schedule>({})
 
   const [responders, setResponders] = useState<Attendee[]>([]) // Set the responders state with the fetched data
   const [hoveredCell, setHoveredCell] = useState<{
@@ -147,6 +148,9 @@ const ViewEvent = () => {
       .then((data) => {
         if (data) {
           //format attendee data
+          setAttendeeTimeSegments(
+            data.map((attendee: Attendee) => attendee.timesegments),
+          )
           const formattedData = formatAttendeeData(data)
           setResponders(formattedData) // Set the responders state with the fetched data
         } else {

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -111,8 +111,6 @@ const ViewEvent = () => {
           mode: data[0].mode,
         }
 
-        console.log('newEvent', newEvent)
-
         setEvent(newEvent)
         // Update the recently viewed events in local storage
         if (!localStorage.getItem('FindingATimeRecentlyViewed')) {

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -20,6 +20,7 @@ import EventFormView from '@/components/EventFormView'
 import Grid from '@/components/AvailabilityGrid'
 import Responses from '@/components/Responses'
 import Username from '@/components/Username'
+import PreferredTimes from '@/components/PreferredTimes'
 
 const ViewEvent = () => {
   const searchParams = useSearchParams()
@@ -109,6 +110,8 @@ const ViewEvent = () => {
           config: data[0].config || {},
           mode: data[0].mode,
         }
+
+        console.log('newEvent', newEvent)
 
         setEvent(newEvent)
         // Update the recently viewed events in local storage
@@ -396,6 +399,10 @@ const ViewEvent = () => {
             className="sticky top-0 h-1 w-full py-8 md:w-[13%]"
           >
             <Responses responders={responders} hoveredCell={hoveredCell} />
+            <PreferredTimes
+              attendeeTimeSegments={attendeeTimeSegments}
+              mode={'weekly'}
+            />
           </section>
         </div>
       </div>


### PR DESCRIPTION
New Features:
1. Users can change their time preferences between regular and preferred using a toggle.
2. Regular times are green and preferred times are blue in the availability grid.
3. Preferred times are listed in descending order of number of participants on the side of the view-event page.

Create-event page using regular and preferred times.
<img width="1342" alt="Screenshot 2024-10-29 at 12 38 19 AM" src="https://github.com/user-attachments/assets/00f9ff73-1d33-490c-ba46-f4851dc85c15">

Editing availability with both regular and preferred using toggle.
<img width="1385" alt="Screenshot 2024-10-29 at 12 46 25 AM" src="https://github.com/user-attachments/assets/ae779056-76a5-4e5c-b92c-998010a997e3">

View-event page showing preferred times listed on the side.
<img width="1384" alt="Screenshot 2024-10-29 at 12 43 09 AM" src="https://github.com/user-attachments/assets/f0d42f48-b1f0-434f-9bf4-8668d822a1d7">

View-event page with multiple users selecting preferred times.
<img width="1383" alt="Screenshot 2024-10-29 at 12 44 51 AM" src="https://github.com/user-attachments/assets/7bdf6865-cad2-4426-b50c-758252bdcd79">

Updated FAQs about preferred times.
<img width="701" alt="Screenshot 2024-11-18 at 12 52 41 PM" src="https://github.com/user-attachments/assets/c33993d2-26c0-4ec2-9198-08fc90f1154f">
